### PR TITLE
FioAPI::Request#fetch: convert HTTParty::Response instance to hash

### DIFF
--- a/lib/base/request.rb
+++ b/lib/base/request.rb
@@ -26,7 +26,7 @@ module FioAPI
     #   Request instance
     #
     def fetch
-      self.response_json = HTTParty.get(uri)
+      self.response_json = HTTParty.get(uri).to_hash
       self
     end
 


### PR DESCRIPTION
`HTTParty::Response` instance needs to be converted into hash before is assigned into `response_json` variable otherwise you get following error: `NoMethodError: undefined method `try_path' for #<HTTParty::Response:0x00000005d96778>`
