### PR TITLE
Fix API URL: https://fioapi.fio.cz/rest/ -> https://fioapi.fio.cz/v1/rest/

### DIFF
--- a/lib/base/list.rb
+++ b/lib/base/list.rb
@@ -14,7 +14,7 @@ module FioAPI
     # == Returns:
     #   List insatnce with account info and transactions list
     #
-    # https://fioapi.fio.cz/rest/periods/(token)/(date_from)/(date_to)/transactions.(format)
+    # https://fioapi.fio.cz/v1/rest/periods/(token)/(date_from)/(date_to)/transactions.(format)
     def by_date_range(from_date, to_date)
       fetch_and_deserialize_response("/periods/#{FioAPI.token}/#{from_date}/#{to_date}/transactions.json")
     end
@@ -30,7 +30,7 @@ module FioAPI
     # == Returns:
     #   List insatnce with account info and transactions list
     #
-    # https://fioapi.fio.cz/rest/by-id/(token)/(year)/(id)/transactions.(format)
+    # https://fioapi.fio.cz/v1/rest/by-id/(token)/(year)/(id)/transactions.(format)
     def by_listing_id_and_year(listing_id, year)
       fetch_and_deserialize_response("/by-id/#{FioAPI.token}/#{year}/#{listing_id}/transactions.json")
     end
@@ -40,7 +40,7 @@ module FioAPI
     # == Returns:
     #   List insatnce with account info and transactions list
     #
-    # https://fioapi.fio.cz/rest/last/(token)/transactions.(format)
+    # https://fioapi.fio.cz/v1/rest/last/(token)/transactions.(format)
     def from_last_fetch
       fetch_and_deserialize_response("/last/#{FioAPI.token}/transactions.json")
     end
@@ -54,7 +54,7 @@ module FioAPI
     # == Returns:
     #   List insatnce with account info and transactions list
     #
-    # https://fioapi.fio.cz/rest/set-last-id/(token)/(id)/
+    # https://fioapi.fio.cz/v1/rest/set-last-id/(token)/(id)/
     def set_last_fetch_id(transaction_id)
       fetch_and_deserialize_response("/set-last-id/#{FioAPI.token}/#{transaction_id}/")
     end
@@ -68,7 +68,7 @@ module FioAPI
     # == Returns:
     #   List insatnce with account info and transactions list
     #
-    # https://fioapi.fio.cz/rest/set-last-date/(token)/(rrrr-mm-dd)/
+    # https://fioapi.fio.cz/v1/rest/set-last-date/(token)/(rrrr-mm-dd)/
     def set_last_fetch_date(date)
       fetch_and_deserialize_response("/set-last-date/#{FioAPI.token}/#{date}/")
     end

--- a/lib/base/request.rb
+++ b/lib/base/request.rb
@@ -4,7 +4,7 @@ module FioAPI
   class Request < FioAPI::Base
     include HTTParty
 
-    base_uri 'https://fioapi.fio.cz/rest/'
+    base_uri 'https://fioapi.fio.cz/v1/rest/'
 
     class << self
       # Reader for token

--- a/spec/base/list_spec.rb
+++ b/spec/base/list_spec.rb
@@ -8,7 +8,7 @@ describe FioAPI::List do
   it 'should set request with uri for date range' do
     date_from = Date.new(2011, 1, 1)
     date_to = Date.new(2012, 11, 25)
-    url = "https://fioapi.fio.cz/rest/periods/#{FioAPI.token}/#{date_from}/#{date_to}/transactions.json"
+    url = "https://fioapi.fio.cz/v1/rest/periods/#{FioAPI.token}/#{date_from}/#{date_to}/transactions.json"
     VCR.use_cassette 'by_date_range', erb: true do
       list = @list.by_date_range(date_from, date_to)
       expect(list.request.uri.to_s).to eq url
@@ -19,7 +19,7 @@ describe FioAPI::List do
   it 'should set request with uri for listing_id and year' do
     year = 2012
     id = '12345'
-    url = "https://fioapi.fio.cz/rest/by-id/#{FioAPI.token}/#{year}/#{id}/transactions.json"
+    url = "https://fioapi.fio.cz/v1/rest/by-id/#{FioAPI.token}/#{year}/#{id}/transactions.json"
     VCR.use_cassette 'by_listing_id_and_year', erb: true do
       list = @list.by_listing_id_and_year(id, year)
       expect(list.request.uri.to_s).to eq url
@@ -28,7 +28,7 @@ describe FioAPI::List do
   end
 
   it 'should set request with uri from last fetch' do
-    url = "https://fioapi.fio.cz/rest/last/#{FioAPI.token}/transactions.json"
+    url = "https://fioapi.fio.cz/v1/rest/last/#{FioAPI.token}/transactions.json"
     VCR.use_cassette 'from_last_fetch', erb: true do
       list = @list.from_last_fetch
       expect(list.request.uri.to_s).to eq url
@@ -38,7 +38,7 @@ describe FioAPI::List do
 
   it 'should set request with uri to set last fetch id' do
     id = '12345'
-    url = "https://fioapi.fio.cz/rest/set-last-id/#{FioAPI.token}/#{id}/"
+    url = "https://fioapi.fio.cz/v1/rest/set-last-id/#{FioAPI.token}/#{id}/"
     VCR.use_cassette 'set_last_fetch_id', erb: true do
       list = @list.set_last_fetch_id(id)
       expect(list.request.uri.to_s).to eq url
@@ -48,7 +48,7 @@ describe FioAPI::List do
 
   it 'should set request with uri to set last date' do
     date = Date.new(2012, 11, 25)
-    url = "https://fioapi.fio.cz/rest/set-last-date/#{FioAPI.token}/#{date}/"
+    url = "https://fioapi.fio.cz/v1/rest/set-last-date/#{FioAPI.token}/#{date}/"
     VCR.use_cassette 'set_last_fetch_date', erb: true do
       list = @list.set_last_fetch_date(date)
       expect(list.request.uri.to_s).to eq url

--- a/spec/fixtures/vcr_cassettes/by_date_range.yml
+++ b/spec/fixtures/vcr_cassettes/by_date_range.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: https://fioapi.fio.cz/rest/periods/<%= FioAPI.token %>/2011-01-01/2012-11-25/transactions.json
+      uri: https://fioapi.fio.cz/v1/rest/periods/<%= FioAPI.token %>/2011-01-01/2012-11-25/transactions.json
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/fixtures/vcr_cassettes/by_listing_id_and_year.yml
+++ b/spec/fixtures/vcr_cassettes/by_listing_id_and_year.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: https://fioapi.fio.cz/rest/by-id/<%= FioAPI.token %>/2012/12345/transactions.json
+      uri: https://fioapi.fio.cz/v1/rest/by-id/<%= FioAPI.token %>/2012/12345/transactions.json
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/fixtures/vcr_cassettes/from_last_fetch.yml
+++ b/spec/fixtures/vcr_cassettes/from_last_fetch.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: https://fioapi.fio.cz/rest/last/<%= FioAPI.token %>/transactions.json
+      uri: https://fioapi.fio.cz/v1/rest/last/<%= FioAPI.token %>/transactions.json
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/fixtures/vcr_cassettes/import.yml
+++ b/spec/fixtures/vcr_cassettes/import.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: post
-      uri: https://fioapi.fio.cz/rest/import/?token=<%= FioAPI.token %>&type=xml
+      uri: https://fioapi.fio.cz/v1/rest/import/?token=<%= FioAPI.token %>&type=xml
       body:
         encoding: UTF-8
         string:

--- a/spec/fixtures/vcr_cassettes/invalid_import.yml
+++ b/spec/fixtures/vcr_cassettes/invalid_import.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: post
-      uri: https://fioapi.fio.cz/rest/import/?token=<%= FioAPI.token %>&type=xml
+      uri: https://fioapi.fio.cz/v1/rest/import/?token=<%= FioAPI.token %>&type=xml
       body:
         encoding: UTF-8
         string:

--- a/spec/fixtures/vcr_cassettes/old_import.yml
+++ b/spec/fixtures/vcr_cassettes/old_import.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: post
-      uri: https://fioapi.fio.cz/rest/import/?token=<%= FioAPI.token %>&type=xml
+      uri: https://fioapi.fio.cz/v1/rest/import/?token=<%= FioAPI.token %>&type=xml
       body:
         encoding: UTF-8
         string:

--- a/spec/fixtures/vcr_cassettes/set_last_fetch_date.yml
+++ b/spec/fixtures/vcr_cassettes/set_last_fetch_date.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: https://fioapi.fio.cz/rest/set-last-date/<%= FioAPI.token %>/2012-11-25/
+      uri: https://fioapi.fio.cz/v1/rest/set-last-date/<%= FioAPI.token %>/2012-11-25/
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/fixtures/vcr_cassettes/set_last_fetch_id.yml
+++ b/spec/fixtures/vcr_cassettes/set_last_fetch_id.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: https://fioapi.fio.cz/rest/set-last-id/<%= FioAPI.token %>/12345/
+      uri: https://fioapi.fio.cz/v1/rest/set-last-id/<%= FioAPI.token %>/12345/
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/fixtures/vcr_cassettes/wrong_token_import.yml
+++ b/spec/fixtures/vcr_cassettes/wrong_token_import.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: post
-      uri: https://fioapi.fio.cz/rest/import/?token=somelongtoken&type=xml
+      uri: https://fioapi.fio.cz/v1/rest/import/?token=somelongtoken&type=xml
       body:
         encoding: UTF-8
         string:


### PR DESCRIPTION
Follow-up to #12: I've updated to v0.0.8 today and started to get HTTP 404 from `FioAPI::List` methods. It turns out that the new URL is actually `https://fioapi.fio.cz/v1/rest/` -- `/v1` is currently missing. The mail from FIO did not include it either, so perhaps that's why it was overlooked. It can be seen at https://www.fio.cz/bankovni-sluzby/api-bankovnictvi.

Thanks for keeping this gem alive!

cc: @martinbarilik