### PR TITLE
fix: intercept deserialization if json variable is String

### DIFF
--- a/lib/base/deserializers/list_response_deserializer.rb
+++ b/lib/base/deserializers/list_response_deserializer.rb
@@ -26,6 +26,8 @@ module FioAPI
     #   New object with account and transactions attributes
     #
     def deserialize(json)
+      return self if json.is_a?(String)
+
       self.account = deserialize_account(json.try_path('accountStatement', 'info'))
       self.transactions = deserialize_transactions(json.try_path('accountStatement', 'transactionList', 'transaction'))
       self

--- a/lib/base/deserializers/list_response_deserializer.rb
+++ b/lib/base/deserializers/list_response_deserializer.rb
@@ -26,7 +26,7 @@ module FioAPI
     #   New object with account and transactions attributes
     #
     def deserialize(json)
-      return self if json.is_a?(String)
+      raise FioAPI::InvalidJsonResponse.new(json) if json.is_a?(String)
 
       self.account = deserialize_account(json.try_path('accountStatement', 'info'))
       self.transactions = deserialize_transactions(json.try_path('accountStatement', 'transactionList', 'transaction'))

--- a/lib/base/errors/invalid_json_response.rb
+++ b/lib/base/errors/invalid_json_response.rb
@@ -1,0 +1,7 @@
+module FioAPI
+    class InvalidJsonResponse < StandardError
+        def initialize(message = "Invalid JSON response")
+            super(message)
+        end
+    end
+end

--- a/lib/fio_api.rb
+++ b/lib/fio_api.rb
@@ -12,12 +12,13 @@ require 'base/payments/xml/root'
 require 'base/payments/xml/item'
 require 'base/deserializers/list_response_deserializer'
 require 'base/deserializers/import_response_deserializer'
+require 'base/errors/invalid_json_response'
 
 module FioAPI
   # == Returns:
   # A string with current version of gem
   #
-  VERSION = '0.0.6'.freeze
+  VERSION = '0.0.10'.freeze
 
   # Set API token for requests
   #


### PR DESCRIPTION
If user requests data older than 30 days, api fails to deserialize response and throws errors.

This prevents app to show any error at all. 

Skipping deserialization allows instance to have empty accounts and transactions. Dev is able to rescue by checking 

`instance.response.format == :plan`

and

instance.response.body being

> Data není možné poskytnout bez silné autorizace. Pokyn k zobrazení dat si autorizujte ve Vašem Internetovém bankovnictví a data si vyžádejte znovu. Platnost ověření je 10 minut od autorizace. Nebo požádejte o data, která nejsou starší jak 90 dní (od 26.12.2024), v takovém případě není autorizace třeba.



this usually hints the error from bank